### PR TITLE
Remove comment from first line to allow hash-bang to work

### DIFF
--- a/uload.sh
+++ b/uload.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/expect #Where the script should be run from.
+#!/usr/bin/expect
 #If it all goes pear shaped the script will timeout after 20 seconds.
 set timeout 20
 #First argument is assigned to the variable ip


### PR DESCRIPTION
I found the `#!` line at the front of the script didn't work on my Linux because the comment was misunderstood by the Linux shell or exec functions. So I removed the comment and it works great for me. Thanks for writing this.