### PR TITLE
Update uload.sh

### DIFF
--- a/uload.sh
+++ b/uload.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/expect #Where the script should be run from.
+#!/usr/bin/expect -f
 #If it all goes pear shaped the script will timeout after 20 seconds.
 set timeout 20
 #First argument is assigned to the variable ip
@@ -20,7 +20,10 @@ spawn telnet $ip $port
 #expect "Connected to $ip."
 expect "Escape character is '^]'."
 sleep 1
-send "if true == file.open(\"$remotefilename\", \"w+\") then \r"
+# Modif Guy. Try: change w+ to a+ on file open and send file by smaller blocks
+# + file.open() doesn't return true or false anymore but an object
+# send "if true == file.open(\"$remotefilename\", \"w+\") then \r"
+send "if nil ~= file.open(\"$remotefilename\", \"a+\") then \r"
 expect ">>"
 send "print(\"ok\")\r"
 expect ">>"
@@ -51,4 +54,4 @@ expect "done"
 sleep 1
 close
 #This hands control of the keyboard over two you (Nice expect feature!)
-#interact 
+#interact


### PR DESCRIPTION
This file needed: it is the wrapper around the other script
[NodeMcuTelnetUploader.txt](https://github.com/balu-/nodemcu-telnet-uploader/files/1203330/NodeMcuTelnetUploader.txt)

improvement done:
1- removing the comment following the shebang #!/usr/bin/expect
   it is causing the expect command to fail
2- file.open() doesn't return true or false anymore but an object
   IMHO this is a NodeMCU firmware change.
   script modified accordingly
3- The original script fails to upload big files (around 100 lines) 
   This is due to a ESP restart during transfer. IMHO heap/memory
   problem. To avoid this I modify the script to send batch of
   60 lines (arbitrary choice) only. So I use the a+ instead of
   w+ when opening the file (append mode). Send batch of 60 lines
   flush, close and start again. 
   To achieve this there is a wrapper bash script calling the 
   expect script. expect script renamed NodeMcuTelnetUploaderByBatch
   (from uload.sh) and wrapper script is NodeMcuTelnetUploader

Usage:
NodeMcuTelnetUploader <NodeMcu IP> <port> <Dest. file> <Source file>

Make sure the file <Dest. file> doesn't exist before transfer 
because it doesn't overwrite but append.

